### PR TITLE
Add offline Rust test runner

### DIFF
--- a/Polkadot Astranet Education/README.md
+++ b/Polkadot Astranet Education/README.md
@@ -222,11 +222,11 @@ The platform includes unit tests for the smart contract examples. To run the tes
    cargo install cargo-contract --force
    ```
 
-2. Run the tests:
+2. Run the tests (offline):
    ```bash
-   cd examples/demo-contracts
-   cargo +nightly test
+   npm test
    ```
+   The script checks for a preinstalled nightly toolchain and cached dependencies.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "http-server 'Polkadot Astranet Education/public' -p 3000 -c-1",
-    "test": "cd 'Polkadot Astranet Education/examples/demo-contracts' && cargo +nightly test"
+    "test": "node scripts/runRustTests.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/runRustTests.js
+++ b/scripts/runRustTests.js
@@ -1,0 +1,48 @@
+const { spawnSync } = require('child_process');
+const path = require('path');
+
+function run(cmd, args, options = {}) {
+  const result = spawnSync(cmd, args, { stdio: 'inherit', ...options });
+  return result.status === 0;
+}
+
+function commandOutput(cmd, args) {
+  return spawnSync(cmd, args, { encoding: 'utf8' }).stdout || '';
+}
+
+function checkRustToolchain() {
+  if (!run('rustup', ['--version'])) {
+    console.error('Error: rustup is not installed. Please install rustup and the nightly toolchain.');
+    process.exit(1);
+  }
+
+  const toolchains = commandOutput('rustup', ['toolchain', 'list']);
+  if (!toolchains.includes('nightly')) {
+    console.error('Error: Rust nightly toolchain not installed. Run `rustup toolchain install nightly` while online.');
+    process.exit(1);
+  }
+}
+
+function checkCargoDeps(projectDir) {
+  const result = spawnSync('cargo', ['+nightly', 'metadata', '--offline'], {
+    cwd: projectDir,
+    stdio: 'inherit'
+  });
+  if (result.status !== 0) {
+    console.error('\nError: Cargo dependencies missing. Run `cargo +nightly fetch` while online to cache dependencies.');
+    process.exit(1);
+  }
+}
+
+function runTests(projectDir) {
+  const result = spawnSync('cargo', ['+nightly', 'test', '--offline'], {
+    cwd: projectDir,
+    stdio: 'inherit'
+  });
+  process.exit(result.status);
+}
+
+const projectDir = path.join(__dirname, '..', 'Polkadot Astranet Education', 'examples', 'demo-contracts');
+checkRustToolchain();
+checkCargoDeps(projectDir);
+runTests(projectDir);


### PR DESCRIPTION
## Summary
- add `scripts/runRustTests.js` to check Rust setup and run contract tests offline
- update npm test script to use the new runner
- document the new offline test flow in the README

## Testing
- `npm test` *(fails: Rust nightly toolchain not installed)*

------
https://chatgpt.com/codex/tasks/task_b_683ee59e00408331984e666baf6571ab