### PR TITLE
Fix ContractDeployer instantiation

### DIFF
--- a/Polkadot Astranet Education/public/js/app.js
+++ b/Polkadot Astranet Education/public/js/app.js
@@ -65,12 +65,9 @@ function initializePolkadot() {
             connector: connector,
             defaultChain: 'polkadot'
         });
-        
-        // Initialize contract deployer
-        const deployer = new ContractDeployer({
-            connector: connector,
-            selector: selector
-        });
+
+        // Initialize contract deployer with connector instance
+        const deployer = new ContractDeployer(connector);
         
         // Store instances in window for global access
         window.polkadotConnector = connector;


### PR DESCRIPTION
## Summary
- fix ContractDeployer initialization in `initializePolkadot`

## Testing
- `npm test` *(fails: Cargo dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_b_683eec695c608331b33a9034a445c290