### PR TITLE
Fix Polkadot extension import

### DIFF
--- a/Polkadot Astranet Education/public/js/framework/polkadot-connector.js
+++ b/Polkadot Astranet Education/public/js/framework/polkadot-connector.js
@@ -165,7 +165,8 @@ class PolkadotConnector {
       throw new Error('Polkadot.js extension not found');
     }
 
-    const { web3Enable, web3Accounts } = await import('https://cdn.jsdelivr.net/npm/@polkadot/extension-dapp@16/+esm');
+    // Use versionless import for extension-dapp to avoid missing version errors
+    const { web3Enable, web3Accounts } = await import('https://cdn.jsdelivr.net/npm/@polkadot/extension-dapp/+esm');
     await web3Enable('Astranet Education Demo');
     const accounts = await web3Accounts();
 


### PR DESCRIPTION
## Summary
- avoid missing version on `@polkadot/extension-dapp`

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_b_683f2b02538c8331bc9c159fe8a03abb