### PR TITLE
Add dev environment setup script

### DIFF
--- a/Polkadot Astranet Education/README.md
+++ b/Polkadot Astranet Education/README.md
@@ -63,9 +63,9 @@ project/
    cd polkadot-educational-platform
    ```
 
-2. Install dependencies:
+2. Set up the development environment:
    ```bash
-   npm install
+   ./scripts/setup_dev_env.sh
    ```
 
 3. Start the development server:

--- a/scripts/setup_dev_env.sh
+++ b/scripts/setup_dev_env.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -e
+
+# Ensure npm is installed
+if command -v npm >/dev/null 2>&1; then
+  echo "Installing Node dependencies with npm ci..."
+  npm ci
+else
+  echo "Error: npm is not installed. Please install Node.js and npm." >&2
+  exit 1
+fi
+
+# Install rustup if missing
+if ! command -v rustup >/dev/null 2>&1; then
+  echo "rustup not found. Installing..."
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+  source "$HOME/.cargo/env"
+fi
+
+# Install nightly toolchain and wasm target
+rustup toolchain install nightly -y
+rustup target add wasm32-unknown-unknown --toolchain nightly
+
+# Install cargo-contract
+cargo install cargo-contract --force
+
+# Cache Rust dependencies if the demo contracts project exists
+DEMO_DIR="Polkadot Astranet Education/examples/demo-contracts"
+if [ -f "$DEMO_DIR/Cargo.toml" ]; then
+  echo "Caching Rust dependencies for demo contracts..."
+  (cd "$DEMO_DIR" && cargo +nightly fetch)
+fi
+
+echo "Development environment setup complete."


### PR DESCRIPTION
## Summary
- add `setup_dev_env.sh` to automate Node and Rust setup
- document setup script in README

## Testing
- `npm test` *(fails: Cargo project not found)*

------
https://chatgpt.com/codex/tasks/task_b_683f2d06164c8331888b59f1cbc7bb92