### PR TITLE
Fix top accounts display and silence RPC warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .env
 *.log
 logs/
+package-lock.json

--- a/Polkadot Astranet Education/public/js/app.js
+++ b/Polkadot Astranet Education/public/js/app.js
@@ -466,7 +466,7 @@ async function loadAccounts() {
         updateAccountsTable(accounts);
     } catch (error) {
         console.error('Error loading accounts:', error);
-        accountsTableBody.innerHTML = `<tr><td colspan="3" class="text-center">Error loading accounts. ${error.message}</td></tr>`;
+        accountsTableBody.innerHTML = `<tr><td colspan="4" class="text-center">Error loading accounts. ${error.message}</td></tr>`;
     }
 }
 
@@ -474,7 +474,7 @@ function updateAccountsTable(accounts) {
     const accountsTableBody = document.querySelector('#accountsTable tbody');
     if (!accountsTableBody) return;
     if (!accounts || accounts.length === 0) {
-        accountsTableBody.innerHTML = `<tr><td colspan="3" class="text-center">No accounts to display.</td></tr>`;
+        accountsTableBody.innerHTML = `<tr><td colspan="4" class="text-center">No accounts to display.</td></tr>`;
         return;
     }
     accountsTableBody.innerHTML = accounts.map((acc, index) => `
@@ -482,6 +482,7 @@ function updateAccountsTable(accounts) {
             <td>${index + 1}</td>
             <td>${acc.address.substring(0,15)}...${acc.address.substring(acc.address.length-10)}</td>
             <td>${(parseFloat(acc.balance) / Math.pow(10, polkadotConnector?.api?.registry.chainDecimals[0] || 12)).toFixed(4)} ${polkadotConnector?.api?.registry.chainTokens[0] || 'UNIT'}</td>
+            <td>${acc.nonce}</td>
         </tr>
     `).join('');
 }

--- a/Polkadot Astranet Education/public/js/framework/polkadot-connector.js
+++ b/Polkadot Astranet Education/public/js/framework/polkadot-connector.js
@@ -37,7 +37,9 @@ class PolkadotConnector {
       const wsProvider = new WsProvider(this.networkEndpoint);
       
       // Create the API instance
-      this.api = await ApiPromise.create({ provider: wsProvider });
+      // noInitWarn suppresses warnings about custom RPC methods that are not
+      // decorated by the library but do not impact core functionality
+      this.api = await ApiPromise.create({ provider: wsProvider, noInitWarn: true });
       
       // Wait for the API to be ready
       await this.api.isReady;


### PR DESCRIPTION
## Summary
- show nonce column in Top Accounts table
- suppress API init warning for custom RPC methods
- ignore `package-lock.json` so it won't be committed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f52c27680833184cc77aac7509dcb