### PR TITLE
Enable real contract deploy via popup

### DIFF
--- a/Polkadot Astranet Education/public/css/styles.css
+++ b/Polkadot Astranet Education/public/css/styles.css
@@ -621,3 +621,29 @@ img {
 .px-3 { padding-left: var(--spacing-md); padding-right: var(--spacing-md); }
 .px-4 { padding-left: var(--spacing-lg); padding-right: var(--spacing-lg); }
 .px-5 { padding-left: var(--spacing-xl); padding-right: var(--spacing-xl); }
+
+/* ===== Modal ===== */
+.modal {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.6);
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: var(--background);
+  padding: var(--spacing-lg);
+  border-radius: var(--border-radius-md);
+  width: 90%;
+  max-width: 500px;
+}
+
+.modal.show {
+  display: flex;
+}

--- a/Polkadot Astranet Education/public/index.html
+++ b/Polkadot Astranet Education/public/index.html
@@ -812,6 +812,25 @@ contract Flipper {
         </div>
     </footer>
 
+    <!-- Deploy Contract Modal -->
+    <div id="deployModal" class="modal">
+        <div class="modal-content">
+            <button class="modal-close btn btn-secondary">&times;</button>
+            <h3 class="mb-3">Deploy Contract</h3>
+            <label for="deployAddress" class="form-label">Deployer Address</label>
+            <input type="text" id="deployAddress" class="form-control mb-3">
+            <label for="deployMnemonic" class="form-label">Deployer Mnemonic</label>
+            <input type="text" id="deployMnemonic" class="form-control mb-3">
+            <label for="deployAbi" class="form-label">ABI JSON</label>
+            <textarea id="deployAbi" class="form-control mb-3" rows="4"></textarea>
+            <label for="deployWasm" class="form-label">WASM Hex</label>
+            <textarea id="deployWasm" class="form-control mb-3" rows="4"></textarea>
+            <label for="deployConstructor" class="form-label">Constructor Args (JSON)</label>
+            <input type="text" id="deployConstructor" class="form-control mb-3" placeholder="[]">
+            <button id="deployModalBtn" class="btn btn-primary">Deploy</button>
+        </div>
+    </div>
+
     <!-- Authentication modals removed -->
 
 


### PR DESCRIPTION
## Summary
- add a deployment modal to gather ABI, WASM and credentials
- style new modal
- trigger modal from Run Contract button
- deploy contract from popup using existing framework

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f5a589ebc83318add5aa26ad4601e