### PR TITLE
Fix explorer tab visibility

### DIFF
--- a/Polkadot Astranet Education/public/css/styles.css
+++ b/Polkadot Astranet Education/public/css/styles.css
@@ -395,6 +395,17 @@ img {
   display: block;
 }
 
+/* ===== Explorer and Dashboard Tabs ===== */
+.explorer-content,
+.dashboard-content {
+  display: none;
+}
+
+.explorer-content.active,
+.dashboard-content.active {
+  display: block;
+}
+
 /* ===== Code Blocks ===== */
 .code-block {
   background-color: var(--dark-gray);


### PR DESCRIPTION
## Summary
- hide explorer and dashboard sections when inactive

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f5c8fbbec83318a0b5c5ca28c7c1b