### PR TITLE
Improve top accounts display

### DIFF
--- a/Polkadot Astranet Education/public/js/app.js
+++ b/Polkadot Astranet Education/public/js/app.js
@@ -45,7 +45,9 @@ async function initializePolkadotFramework() {
     console.log('Initializing Polkadot framework...');
     try {
         polkadotConnector = new PolkadotConnector({
-            networkEndpoint: 'wss://rpc.polkadot.io' // Default network
+            networkEndpoint: 'wss://rpc.polkadot.io', // Default network
+            networkId: 'polkadot',
+            explorerUrl: 'https://polkadot.subscan.io'
         });
 
         polkadotConnector.addConnectionListener(handleConnectionStatusChange);
@@ -458,7 +460,7 @@ async function loadAccounts() {
         return;
     }
     try {
-        const accounts = await polkadotConnector.getTopAccounts(5);
+        const accounts = await polkadotConnector.getTopAccounts(10);
         updateAccountsTable(accounts);
     } catch (error) {
         console.error('Error loading accounts:', error);
@@ -858,7 +860,11 @@ async function handleNetworkChange(event) {
         }
         
         // Create and connect new connector
-        polkadotConnector = new PolkadotConnector({ networkEndpoint: selectedNetwork.endpoint });
+        polkadotConnector = new PolkadotConnector({
+            networkEndpoint: selectedNetwork.endpoint,
+            networkId: selectedNetwork.id,
+            explorerUrl: selectedNetwork.explorerUrl
+        });
         polkadotConnector.addConnectionListener(handleConnectionStatusChange); // Re-add listener
         
         await polkadotConnector.connect();

--- a/Polkadot Astranet Education/public/js/framework/blockchain-selector.js
+++ b/Polkadot Astranet Education/public/js/framework/blockchain-selector.js
@@ -80,7 +80,9 @@ class BlockchainSelector {
 
       // Create a new connector with the selected network
       this.connector = new PolkadotConnector({
-        networkEndpoint: network.endpoint
+        networkEndpoint: network.endpoint,
+        networkId: network.id,
+        explorerUrl: network.explorerUrl
       });
 
       // Connect to the network
@@ -172,7 +174,9 @@ class BlockchainSelector {
       testEndpoints.map(async (network) => {
         try {
           const tempConnector = new PolkadotConnector({
-            networkEndpoint: network.endpoint
+            networkEndpoint: network.endpoint,
+            networkId: network.id,
+            explorerUrl: network.explorerUrl
           });
           
           // Try to connect with a timeout
@@ -226,7 +230,9 @@ class BlockchainSelector {
         tempConnector = this.connector;
       } else {
         tempConnector = new PolkadotConnector({
-          networkEndpoint: network.endpoint
+          networkEndpoint: network.endpoint,
+          networkId: network.id,
+          explorerUrl: network.explorerUrl
         });
         await tempConnector.connect();
         shouldDisconnect = true;


### PR DESCRIPTION
## Summary
- pull top account data from Subscan before falling back to on-chain iteration
- pass network id and explorer url to `PolkadotConnector`
- show ten accounts instead of five

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f60ca24488331969a63331c109cca