### PR TITLE
Add Firebase progress tracking with login button

### DIFF
--- a/Polkadot Astranet Education/public/code/progress.js
+++ b/Polkadot Astranet Education/public/code/progress.js
@@ -1,0 +1,69 @@
+import { initializeApp, getApp } from 'https://www.gstatic.com/firebasejs/9.6.7/firebase-app.js';
+import { getAuth } from 'https://www.gstatic.com/firebasejs/9.6.7/firebase-auth.js';
+import { getDatabase, ref as rtdbRef, get, set } from 'https://www.gstatic.com/firebasejs/9.6.7/firebase-database.js';
+import firebaseConfig from '../Firebase/firebase-config.js';
+
+let app;
+try {
+  app = getApp();
+} catch {
+  app = initializeApp(firebaseConfig);
+}
+
+const auth = getAuth(app);
+const rtdb = getDatabase(app);
+
+const loginBtn = document.getElementById('loginNavBtn');
+
+async function fetchProgress(uid) {
+  const snap = await get(rtdbRef(rtdb, `users/${uid}/progress`));
+  return snap.exists() ? snap.val() : 0;
+}
+
+async function saveProgress(uid, progress) {
+  await set(rtdbRef(rtdb, `users/${uid}/progress`), progress);
+}
+
+// Update UI when progress is loaded
+function updateProgressUI(value) {
+  const circle = document.getElementById('learningProgressCircle');
+  if (!circle) return;
+  circle.setAttribute('data-progress', value);
+  const text = circle.querySelector('.progress-text');
+  if (text) text.textContent = `${value}%`;
+}
+
+// Listen for login/logout events
+document.addEventListener('app:userLoggedIn', async (e) => {
+  const uid = e.detail.user.uid;
+  const progress = await fetchProgress(uid);
+  updateProgressUI(progress);
+  document.dispatchEvent(new CustomEvent('progress:loaded', { detail: progress }));
+  if (loginBtn) {
+    loginBtn.textContent = 'Logout';
+    loginBtn.removeAttribute('href');
+    loginBtn.addEventListener('click', handleLogoutClick);
+  }
+});
+
+document.addEventListener('app:userLoggedOut', () => {
+  updateProgressUI(0);
+  if (loginBtn) {
+    loginBtn.textContent = 'Login';
+    loginBtn.setAttribute('href', 'auth/login.html');
+    loginBtn.removeEventListener('click', handleLogoutClick);
+  }
+});
+
+// Save progress events from app.js
+document.addEventListener('progress:save', async (e) => {
+  const user = auth.currentUser;
+  if (user) {
+    await saveProgress(user.uid, e.detail);
+  }
+});
+
+function handleLogoutClick(e) {
+  e.preventDefault();
+  document.dispatchEvent(new CustomEvent('app:requestLogout'));
+}

--- a/Polkadot Astranet Education/public/css/styles.css
+++ b/Polkadot Astranet Education/public/css/styles.css
@@ -507,6 +507,36 @@ img {
   font-size: 1.25rem;
 }
 
+.nav-login-btn {
+  margin-left: var(--spacing-lg);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border: 1px solid var(--primary);
+  border-radius: var(--border-radius-sm);
+  color: var(--primary);
+  font-weight: 500;
+}
+
+.nav-login-btn:hover,
+.nav-login-btn:focus-visible {
+  background: var(--primary);
+  color: var(--white);
+}
+
+.progress-circle {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  background: var(--background-alt);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+}
+
+.progress-circle .progress-text {
+  font-size: 1rem;
+}
+
 /* ===== Responsive Design ===== */
 @media (max-width: 992px) {
   h1 {

--- a/Polkadot Astranet Education/public/index.html
+++ b/Polkadot Astranet Education/public/index.html
@@ -42,7 +42,9 @@
                 <button class="dark-mode-toggle" id="darkModeToggle">
                     <i class="fas fa-moon"></i>
                 </button>
-                
+
+                <a href="auth/login.html" class="nav-login-btn" id="loginNavBtn">Login</a>
+
                 <button class="mobile-menu-toggle" id="mobileMenuToggle">
                     <i class="fas fa-bars"></i>
                 </button>
@@ -841,5 +843,7 @@ contract Flipper {
     <script type="module" src="js/framework/blockchain-selector.js"></script>
     <script type="module" src="js/framework/contract-deployer.js"></script>
     <script type="module" src="js/app.js"></script>
+    <script type="module" src="code/auth.js"></script>
+    <script type="module" src="code/progress.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add login button to site header and include auth/progress scripts
- style login button and progress display
- implement simple progress tracking via Firebase RTDB
- allow logout from nav button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f6695d878833184bac70ae8787c4f