### PR TITLE
Fix login redirect and default progress handling

### DIFF
--- a/Polkadot Astranet Education/README.md
+++ b/Polkadot Astranet Education/README.md
@@ -103,6 +103,8 @@ project/
 5. Track your transaction history
 6. Earn achievements as you learn
 
+User progress is stored under each account at `users/{uid}/polkadot-astranet-education/progress` in Firebase Realtime Database. If no progress record exists, the application automatically initializes this node to `0` upon login.
+
 ## Configuration
 
 ### Firebase Configuration

--- a/Polkadot Astranet Education/firebase.rules.json
+++ b/Polkadot Astranet Education/firebase.rules.json
@@ -1,0 +1,40 @@
+{
+  "rules": {
+    "users": {
+      "$uid": {
+        ".read": "auth != null && auth.uid == $uid",
+        ".write": "auth != null && auth.uid == $uid",
+        "chatHistory": {
+          ".indexOn": ["createdAt", "lastActivity"],
+          "$chatId": {
+            ".read": "auth != null && auth.uid == $uid",
+            ".write": "auth != null && ((newData.exists() && newData.child('participants/' + auth.uid).exists()) || (data.exists() && data.child('participants/' + auth.uid).exists()))",
+            "messages": {
+              "$messageId": {
+                ".read": "auth != null && auth.uid == $uid",
+                ".write": "auth != null && auth.uid == $uid && newData.child('sender').val() == auth.uid && root.child('users/' + $uid + '/chatHistory/' + $chatId + '/participants/' + auth.uid).exists()"
+              }
+            },
+            "name": { ".validate": "newData.isString()" },
+            "lastActivity": { ".validate": "newData.isNumber() || newData.val() == now" },
+            "lastMessagePreview": { ".validate": "newData.isString()" }
+          }
+        }
+      }
+    },
+    "astranet-assistant": {
+      "chatHistory": {
+        ".indexOn": ["createdAt", "lastActivity"],
+        "$chatId": {
+          ".read": "auth != null && data.child('participants/' + auth.uid).exists()",
+          ".write": "auth != null && ((newData.exists() && newData.child('participants/' + auth.uid).exists()) || (data.exists() && data.child('participants/' + auth.uid).exists()))"
+        }
+      }
+    },
+    "admins": {
+      "$uid": {
+        ".read": "auth != null"
+      }
+    }
+  }
+}

--- a/Polkadot Astranet Education/public/Firebase/default-progress.json
+++ b/Polkadot Astranet Education/public/Firebase/default-progress.json
@@ -1,0 +1,6 @@
+{
+  "progress": 0,
+  "contracts": 0,
+  "transactions": 0,
+  "achievements": 0
+}

--- a/Polkadot Astranet Education/public/code/auth.js
+++ b/Polkadot Astranet Education/public/code/auth.js
@@ -332,7 +332,7 @@ document.addEventListener('app:userLoggedIn', (event) => {
     } else if (user && user.emailVerified && window.location.pathname.startsWith('/auth/login') && !loginRedirectTriggered) {
           popupNotifier.success('¡Inicio de sesión exitoso! Redirigiendo...', 'Inicio exitoso');
         loginRedirectTriggered = true;
-        window.location.href = '/inicio/landing.html';
+        window.location.href = '/index.html';
     }
 });
 

--- a/Polkadot Astranet Education/public/code/progress.js
+++ b/Polkadot Astranet Education/public/code/progress.js
@@ -15,13 +15,22 @@ const rtdb = getDatabase(app);
 
 const loginBtn = document.getElementById('loginNavBtn');
 
+function progressRef(uid) {
+  return rtdbRef(rtdb, `users/${uid}/polkadot-astranet-education/progress`);
+}
+
 async function fetchProgress(uid) {
-  const snap = await get(rtdbRef(rtdb, `users/${uid}/progress`));
-  return snap.exists() ? snap.val() : 0;
+  const ref = progressRef(uid);
+  const snap = await get(ref);
+  if (snap.exists()) {
+    return snap.val();
+  }
+  await set(ref, 0);
+  return 0;
 }
 
 async function saveProgress(uid, progress) {
-  await set(rtdbRef(rtdb, `users/${uid}/progress`), progress);
+  await set(progressRef(uid), progress);
 }
 
 // Update UI when progress is loaded


### PR DESCRIPTION
## Summary
- fix login redirect path to return to index
- set progress under `users/{uid}/polkadot-astranet-education/progress` with a default 0 value
- document progress location
- add Firebase security rules skeleton and default progress sample

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f6a2bb9888331b3a734ac06f1a735