### PR TITLE
Update login/logout redirects

### DIFF
--- a/Polkadot Astranet Education/public/code/auth.js
+++ b/Polkadot Astranet Education/public/code/auth.js
@@ -328,16 +328,20 @@ document.addEventListener('app:userLoggedIn', (event) => {
     if (error) {
         console.error("Login/Profile fetch error reported to UI:", error);
     } else if (needsVerification) {
-         popupNotifier.info('Revisa tu correo para verificar tu cuenta antes de iniciar sesión.', 'Verificar correo');
-    } else if (user && user.emailVerified && window.location.pathname.startsWith('/auth/login') && !loginRedirectTriggered) {
-          popupNotifier.success('¡Inicio de sesión exitoso! Redirigiendo...', 'Inicio exitoso');
+        popupNotifier.info('Revisa tu correo para verificar tu cuenta antes de iniciar sesión.', 'Verificar correo');
+    } else if (user && user.emailVerified && window.location.pathname.includes('/auth/login') && !loginRedirectTriggered) {
+        popupNotifier.success('¡Inicio de sesión exitoso! Redirigiendo...', 'Inicio exitoso');
         loginRedirectTriggered = true;
-        window.location.href = '/index.html';
+        window.location.href = '/public/index.html';
     }
 });
 
 document.addEventListener('app:userLoggedOut', () => {
-    console.log('User logged out (UI event)');
+    const referrer = document.referrer;
+    const refUrl = referrer ? new URL(referrer) : null;
+    const sameOrigin = refUrl && refUrl.origin === window.location.origin;
+    const target = sameOrigin ? refUrl.pathname + refUrl.search + refUrl.hash : '/public/index.html';
+    window.location.href = target;
 });
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- redirect to `/public/index.html` after successful login
- when logging out, return to the referring page or default to `/public/index.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f6d459da083319863006544435abd