### PR TITLE
Fix login redirect loop

### DIFF
--- a/Polkadot Astranet Education/public/code/app.js
+++ b/Polkadot Astranet Education/public/code/app.js
@@ -8,8 +8,9 @@ if (isLoggedIn()) {
   // Redirect to login or show guest UI
 }
 
-if (!isLoggedIn() && window.location.pathname !== '/auth/login.html') {
-  window.location.href = '/auth/login.html';
+if (!isLoggedIn() && !window.location.pathname.includes('/auth/login')) {
+  // use relative path so it works when served from /public/
+  window.location.href = 'auth/login.html';
 }
 
 // Blog logic removed

--- a/Polkadot Astranet Education/public/code/auth.js
+++ b/Polkadot Astranet Education/public/code/auth.js
@@ -337,11 +337,11 @@ document.addEventListener('app:userLoggedIn', (event) => {
 });
 
 document.addEventListener('app:userLoggedOut', () => {
-    const referrer = document.referrer;
-    const refUrl = referrer ? new URL(referrer) : null;
-    const sameOrigin = refUrl && refUrl.origin === window.location.origin;
-    const target = sameOrigin ? refUrl.pathname + refUrl.search + refUrl.hash : '/public/index.html';
-    window.location.href = target;
+    // Avoid redirect loop: stay on login page when already there
+    if (window.location.pathname.includes('/auth/login')) {
+        return;
+    }
+    window.location.href = '/public/auth/login.html';
 });
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- avoid redirecting users away from the login screen if no auth data
- fix relative path for auth redirects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f6eddde9483319e1f7a032c78484a