### PR TITLE
Fix login redirect paths

### DIFF
--- a/Polkadot Astranet Education/public/code/auth.js
+++ b/Polkadot Astranet Education/public/code/auth.js
@@ -332,7 +332,7 @@ document.addEventListener('app:userLoggedIn', (event) => {
     } else if (user && user.emailVerified && window.location.pathname.includes('/auth/login') && !loginRedirectTriggered) {
         popupNotifier.success('¡Inicio de sesión exitoso! Redirigiendo...', 'Inicio exitoso');
         loginRedirectTriggered = true;
-        window.location.href = '/public/index.html';
+        window.location.href = 'index.html';
     }
 });
 
@@ -341,7 +341,7 @@ document.addEventListener('app:userLoggedOut', () => {
     if (window.location.pathname.includes('/auth/login')) {
         return;
     }
-    window.location.href = '/public/auth/login.html';
+    window.location.href = 'auth/login.html';
 });
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- fix absolute redirect paths in auth.js to work in hosted `/public` folder

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f7db81b948331a4e46cfa1c80b8b3