### PR TITLE
Add login modal

### DIFF
--- a/Polkadot Astranet Education/public/code/auth.js
+++ b/Polkadot Astranet Education/public/code/auth.js
@@ -329,19 +329,20 @@ document.addEventListener('app:userLoggedIn', (event) => {
         console.error("Login/Profile fetch error reported to UI:", error);
     } else if (needsVerification) {
         popupNotifier.info('Revisa tu correo para verificar tu cuenta antes de iniciar sesión.', 'Verificar correo');
-    } else if (user && user.emailVerified && window.location.pathname.includes('/auth/login') && !loginRedirectTriggered) {
-        popupNotifier.success('¡Inicio de sesión exitoso! Redirigiendo...', 'Inicio exitoso');
-        loginRedirectTriggered = true;
-        window.location.href = 'index.html';
+    } else if (user && user.emailVerified) {
+        popupNotifier.success('¡Inicio de sesión exitoso!', 'Inicio exitoso');
+        const modal = document.getElementById('loginModal');
+        if (modal) modal.style.display = 'none';
+        if (window.location.pathname.includes('/auth/login') && !loginRedirectTriggered) {
+            loginRedirectTriggered = true;
+            window.location.href = 'index.html';
+        }
     }
 });
 
 document.addEventListener('app:userLoggedOut', () => {
-    // Avoid redirect loop: stay on login page when already there
-    if (window.location.pathname.includes('/auth/login')) {
-        return;
-    }
-    window.location.href = 'auth/login.html';
+    const modal = document.getElementById('loginModal');
+    if (modal) modal.style.display = 'none';
 });
 
 if (document.readyState === 'loading') {

--- a/Polkadot Astranet Education/public/code/progress.js
+++ b/Polkadot Astranet Education/public/code/progress.js
@@ -14,6 +14,12 @@ const auth = getAuth(app);
 const rtdb = getDatabase(app);
 
 const loginBtn = document.getElementById('loginNavBtn');
+const loginModal = document.getElementById('loginModal');
+
+function openLoginModal(e) {
+  if (e) e.preventDefault();
+  if (loginModal) loginModal.style.display = 'flex';
+}
 
 function progressRef(uid) {
   return rtdbRef(rtdb, `users/${uid}/polkadot-astranet-education/progress`);
@@ -50,6 +56,7 @@ document.addEventListener('app:userLoggedIn', async (e) => {
   document.dispatchEvent(new CustomEvent('progress:loaded', { detail: progress }));
   if (loginBtn) {
     loginBtn.textContent = 'Logout';
+    loginBtn.removeEventListener('click', openLoginModal);
     loginBtn.removeAttribute('href');
     loginBtn.addEventListener('click', handleLogoutClick);
   }
@@ -59,8 +66,9 @@ document.addEventListener('app:userLoggedOut', () => {
   updateProgressUI(0);
   if (loginBtn) {
     loginBtn.textContent = 'Login';
-    loginBtn.setAttribute('href', 'auth/login.html');
     loginBtn.removeEventListener('click', handleLogoutClick);
+    loginBtn.removeAttribute('href');
+    loginBtn.addEventListener('click', openLoginModal);
   }
 });
 
@@ -75,4 +83,8 @@ document.addEventListener('progress:save', async (e) => {
 function handleLogoutClick(e) {
   e.preventDefault();
   document.dispatchEvent(new CustomEvent('app:requestLogout'));
+}
+
+if (loginBtn) {
+  loginBtn.addEventListener('click', openLoginModal);
 }

--- a/Polkadot Astranet Education/public/index.html
+++ b/Polkadot Astranet Education/public/index.html
@@ -20,6 +20,7 @@
     
     <!-- Custom CSS -->
     <link rel="stylesheet" href="css/styles.css">
+    <link rel="stylesheet" href="assets/css/auth/login.css">
 </head>
 <body>
     <!-- Header -->
@@ -43,7 +44,7 @@
                     <i class="fas fa-moon"></i>
                 </button>
 
-                <a href="auth/login.html" class="nav-login-btn" id="loginNavBtn">Login</a>
+                <a href="#" class="nav-login-btn" id="loginNavBtn">Login</a>
 
                 <button class="mobile-menu-toggle" id="mobileMenuToggle">
                     <i class="fas fa-bars"></i>
@@ -863,7 +864,46 @@ contract Flipper {
         </div>
     </div>
 
-    <!-- Authentication modals removed -->
+    <!-- Login / Sign Up Modal -->
+    <div id="loginModal" class="modal" role="dialog" aria-modal="true">
+        <div class="modal-content">
+            <div class="auth-widget" id="loginWidget">
+                <h2 id="loginModalTitle">Login</h2>
+                <label for="loginEmail">Email</label>
+                <input type="email" id="loginEmail" placeholder="Email">
+
+                <label for="loginPassword">Password</label>
+                <div class="password-container">
+                    <input type="password" id="loginPassword" placeholder="Enter your password">
+                    <button class="toggle-password"><img id="loginEyeImg" src="assets/png/eye.png" alt="Mostrar contraseña" /></button>
+                </div>
+
+                <button id="signInButton" class="auth-button primary">Login</button>
+                <p class="switch-auth">Don't have an account? <a href="#" id="showSignUp">Sign Up</a></p>
+            </div>
+
+            <div class="auth-widget hidden" id="signUpWidget">
+                <h2>Sign Up</h2>
+                <label for="signUpEmail">Email</label>
+                <input type="email" id="signUpEmail" placeholder="Enter your email">
+
+                <label for="signUpPassword">Password</label>
+                <div class="password-container">
+                    <input type="password" id="signUpPassword" placeholder="Choose a password (min. 6 characters)">
+                    <button class="toggle-password"><img id="signUpEyeImg" src="assets/png/eye.png" alt="Mostrar contraseña" /></button>
+                </div>
+
+                <label for="confirmPassword">Confirm Password</label>
+                <div class="password-container">
+                    <input type="password" id="confirmPassword" placeholder="Confirm your password">
+                </div>
+
+                <button id="signUpButton" class="auth-button primary">Sign Up</button>
+                <p class="switch-auth">Already have an account? <a href="#" id="showLogin">Login</a></p>
+            </div>
+        </div>
+    </div>
+
 
 
     <!-- Code Editor (Monaco) -->


### PR DESCRIPTION
## Summary
- integrate login modal into main page instead of separate login page
- update progress tracking script to open modal and handle logout
- close modal on login/logout events

## Testing
- `node scripts/runRustTests.js`

------
https://chatgpt.com/codex/tasks/task_b_683f7fa566388331adbd35471f9d1f45